### PR TITLE
support go://linkname

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -834,7 +834,7 @@ func (s *Session) buildPackage(pkg *PackageData) (*compiler.Archive, error) {
 				}
 			}
 		}
-		f, err := parser.ParseFile(fileSet, "_linknames", []byte(strings.Join(lines, "\n")), 0)
+		f, err := parser.ParseFile(fileSet, "_linknames", []byte(strings.Join(lines, "\n")+"\n"), 0)
 		if err != nil {
 			return nil, err
 		}

--- a/build/build.go
+++ b/build/build.go
@@ -820,7 +820,8 @@ func (s *Session) buildPackage(pkg *PackageData) (*compiler.Archive, error) {
 		}
 		sort.Strings(linkImports)
 		var lines []string
-		lines = append(lines, "package "+pkg.Name)
+		_, pkgName := path.Split(pkg.ImportPath)
+		lines = append(lines, "package "+pkgName)
 		for _, im := range linkImports {
 			lines = append(lines, "import _ \""+im+"\"")
 			if ar := s.Archives[im]; ar != nil {
@@ -834,7 +835,7 @@ func (s *Session) buildPackage(pkg *PackageData) (*compiler.Archive, error) {
 				}
 			}
 		}
-		f, err := parser.ParseFile(fileSet, "_linknames", []byte(strings.Join(lines, "\n")+"\n"), 0)
+		f, err := parser.ParseFile(fileSet, "_linkname.go", []byte(strings.Join(lines, "\n")+"\n"), 0)
 		if err != nil {
 			return nil, err
 		}

--- a/build/build.go
+++ b/build/build.go
@@ -803,7 +803,7 @@ func (s *Session) buildPackage(pkg *PackageData) (*compiler.Archive, error) {
 		},
 	}
 
-	if len(linknames) > 0 && pkg.Name != "bytealg" {
+	if len(linknames) > 0 && pkg.ImportPath != "internal/bytealg" {
 		var linkImports []string
 		for _, link := range linknames {
 			if link.TargetImportPath != "" {

--- a/compiler/natives/src/syscall/syscall_darwin.go
+++ b/compiler/natives/src/syscall/syscall_darwin.go
@@ -244,12 +244,16 @@ func syscall(trap, a1, a2, a3 uintptr) (r1, r2 uintptr, err Errno) {
 	return Syscall(trap, a1, a2, a3)
 }
 
+func syscallX(trap, a1, a2, a3 uintptr) (r1, r2 uintptr, err Errno) {
+	return Syscall(trap, a1, a2, a3)
+}
+
 func syscall6(trap, a1, a2, a3, a4, a5, a6 uintptr) (r1, r2 uintptr, err Errno) {
 	return Syscall6(trap, a1, a2, a3, a4, a5, a6)
 }
 
 func syscall6X(trap, a1, a2, a3, a4, a5, a6 uintptr) (r1, r2 uintptr, err Errno) {
-	panic("syscall6X is not implemented")
+	return Syscall6(trap, a1, a2, a3, a4, a5, a6)
 }
 
 func rawSyscall(trap, a1, a2, a3 uintptr) (r1, r2 uintptr, err Errno) {

--- a/compiler/natives/src/time/time.go
+++ b/compiler/natives/src/time/time.go
@@ -80,3 +80,5 @@ var zoneSources = []string{
 func indexByte(s string, c byte) int {
 	return js.InternalObject(s).Call("indexOf", js.Global.Get("String").Call("fromCharCode", c)).Int()
 }
+
+var GopherJSregisterLoadFromEmbeddedTZData = registerLoadFromEmbeddedTZData

--- a/compiler/natives/src/time/time.go
+++ b/compiler/natives/src/time/time.go
@@ -80,5 +80,3 @@ var zoneSources = []string{
 func indexByte(s string, c byte) int {
 	return js.InternalObject(s).Call("indexOf", js.Global.Get("String").Call("fromCharCode", c)).Int()
 }
-
-var GopherJSregisterLoadFromEmbeddedTZData = registerLoadFromEmbeddedTZData

--- a/compiler/package.go
+++ b/compiler/package.go
@@ -412,7 +412,10 @@ func Compile(importPath string, files []*ast.File, fileSet *token.FileSet, impor
 		if fun.Body == nil {
 			for _, link := range linknames {
 				if link.Local == fun.Name.Name {
-					d.DeclCode = []byte("\t" + link.Local + "=" + link.Target + ";\n")
+					d.DeclCode = []byte(fmt.Sprintf("\t%v=%v.%v;\n",
+						c.p.objectNames[o],
+						c.p.pkgVars[link.TargetImportPath],
+						link.TargetName))
 					d.DceDeps = append(d.DceDeps, link.Target)
 					break
 				}

--- a/compiler/package.go
+++ b/compiler/package.go
@@ -8,6 +8,7 @@ import (
 	"go/constant"
 	"go/token"
 	"go/types"
+	"log"
 	"sort"
 	"strings"
 
@@ -276,6 +277,9 @@ func Compile(importPath string, files []*ast.File, fileSet *token.FileSet, impor
 								o := c.p.Defs[name].(*types.Var)
 								vars = append(vars, o)
 								c.objectName(o) // register toplevel name
+								if importPath == "time/tzdata" {
+									log.Println("---->", c.p.Defs)
+								}
 							}
 						}
 					}

--- a/tool.go
+++ b/tool.go
@@ -398,7 +398,7 @@ func main() {
 						return s.BuildImportPath(path)
 					},
 				}
-				mainPkgArchive, err := compiler.Compile("main", []*ast.File{mainFile}, fset, importContext, options.Minify)
+				mainPkgArchive, err := compiler.Compile("main", []*ast.File{mainFile}, fset, importContext, nil, options.Minify)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
fixed https://github.com/goplusjs/gopherjs/issues/1

//go:linkname localname [importpath.name]

parse and generate local name for import target.name, generate target export name

example  package time/tzdata

```
//go:linkname registerLoadFromEmbeddedTZData time.registerLoadFromEmbeddedTZData
func registerLoadFromEmbeddedTZData(func(string) (string, error))
```

time.js
```
$pkg.registerLoadFromEmbeddedTZData= registerLoadFromEmbeddedTZData
```

tzdata.js
```
registerLoadFromEmbeddedTZData=time.registerLoadFromEmbeddedTZData
```




