### PR TITLE
fix #14, go mod using for go1.15

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -214,6 +214,8 @@ func importWithSrcDir(bctx build.Context, path string, srcDir string, mode build
 	case "crypto/rand":
 		pkg.GoFiles = []string{"rand.go", "util.go"}
 		pkg.TestGoFiles = exclude(pkg.TestGoFiles, "rand_linux_test.go") // Don't want linux-specific tests (since linux-specific package files are excluded too).
+	case "syscall":
+		pkg.GoFiles = exclude(pkg.GoFiles, "ptrace_ios.go")
 	}
 
 	if len(pkg.CgoFiles) > 0 {

--- a/compiler/version.go
+++ b/compiler/version.go
@@ -1,4 +1,4 @@
 package compiler
 
 // Version is the GopherJS compiler version string.
-const Version = "1.15"
+const Version = "1.16rc1"

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5
 	github.com/visualfc/fastmod v1.3.6
-	github.com/visualfc/goembed v0.1.0
+	github.com/visualfc/goembed v0.1.2
 	github.com/visualfc/goversion v1.0.0
 	golang.org/x/crypto v0.0.0-20200208060501-ecb85df21340
 	golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9

--- a/go.sum
+++ b/go.sum
@@ -41,8 +41,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/visualfc/fastmod v1.3.6 h1:gFvAxk6VoEbk0JF1XP0KznbQl5hYJN9ZYhRYQy3pcKs=
 github.com/visualfc/fastmod v1.3.6/go.mod h1:IpOumy9gVomQ72T+yA7gayE3V1FCNlwr6if3mlqnasY=
-github.com/visualfc/goembed v0.1.0 h1:KP+r3tyP1TZgXt/A3b/6Dsmkj7wq6WfVUFKXnUNNEFw=
-github.com/visualfc/goembed v0.1.0/go.mod h1:jCVCz/yTJGyslo6Hta+pYxWWBuq9ADCcIVZBTQ0/iVI=
+github.com/visualfc/goembed v0.1.2 h1:jAJgIEATpp1qpm3VrJC4Pu1w/jbKoSB1gx7SQk/wfkU=
+github.com/visualfc/goembed v0.1.2/go.mod h1:jCVCz/yTJGyslo6Hta+pYxWWBuq9ADCcIVZBTQ0/iVI=
 github.com/visualfc/goversion v1.0.0 h1:FAgKP4pat4gzRovdiT7AqxLG3oZXhmJVd7FekcjKnls=
 github.com/visualfc/goversion v1.0.0/go.mod h1:hk2JexdCD524I4uxWPUf6e++g7ZaCMu6TC7xESs/soc=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=


### PR DESCRIPTION
https://github.com/visualfc/goembed wrap io/fs for go1.15